### PR TITLE
Corrección de las rutas y busqueda de ficheros

### DIFF
--- a/Nimter/Core/Init/ConfigReader.php
+++ b/Nimter/Core/Init/ConfigReader.php
@@ -32,7 +32,7 @@ class ConfigReader
     public static function config()
     {
         //Obtenemos la configuración de Nimter
-        $config = Yaml::parse(file_get_contents('Nimter\Core\init\Nimter.yml'));
+        $config = Yaml::parse(file_get_contents('Nimter/Core/init/Nimter.yml'));
         return $config;
     }
 }

--- a/index.php
+++ b/index.php
@@ -15,4 +15,4 @@
 define('__PATH__', '');
 
 //Carga el framework
-require_once __PATH__ . 'Nimter/Core/init/Init.php';
+require_once __PATH__ . 'Nimter/Core/Init/Init.php';


### PR DESCRIPTION
* Se corrige el error en la ruta al archivo de inicialización del framework.
* Se dejan de usar backslashes y en su lugar se usan slashes que son compatibles con SO windows y unix.