### PR TITLE
Conn2db -Se han eliminado los dos puntos extra que tenia el conector …

### DIFF
--- a/Nimter/Core/Helpers/Conn2db.php
+++ b/Nimter/Core/Helpers/Conn2db.php
@@ -73,7 +73,7 @@ class Conn2db
     protected function connection()
     {
         try {
-            $connector = $this->driver . '::host=' . $this->host . ';dbname=' . $this->DBname;
+            $connector = $this->driver . ':host=' . $this->host . ';dbname=' . $this->DBname;
 
             $attributes = array(
                 PDO::ATTR_PERSISTENT => false,


### PR DESCRIPTION
…de PDO. -Se ha arreglado el error de sintaxis en el conector, que hacia que no se reconociera el driver de base de datos.